### PR TITLE
feature-profile-likes

### DIFF
--- a/cloudfunctions/getUserLikes/index.js
+++ b/cloudfunctions/getUserLikes/index.js
@@ -1,0 +1,74 @@
+// 云函数入口文件
+const cloud = require('wx-server-sdk')
+
+cloud.init({
+  env: 'nkuwiki-0g6bkdy9e8455d93'
+})
+
+const db = cloud.database()
+
+// 云函数入口函数
+exports.main = async (event, context) => {
+  const wxContext = cloud.getWXContext()
+  const { openid } = event
+  
+  // 使用传入的openid或当前用户的openid
+  const userOpenid = openid || wxContext.OPENID
+
+  if (!userOpenid) {
+    return {
+      success: false,
+      message: '未获取到用户ID'
+    }
+  }
+
+  try {
+    // 查询用户信息
+    const userQuery = await db.collection('users').where({
+      openid: userOpenid
+    }).get()
+
+    if (!userQuery.data || userQuery.data.length === 0) {
+      return {
+        success: false,
+        message: '用户不存在'
+      }
+    }
+
+    const user = userQuery.data[0]
+    
+    // 查询用户发布的所有帖子
+    const postsQuery = await db.collection('posts').where({
+      _openid: userOpenid
+    }).get()
+    
+    // 计算所有帖子获得的点赞总数
+    let totalLikes = 0
+    if (postsQuery.data && postsQuery.data.length > 0) {
+      postsQuery.data.forEach(post => {
+        totalLikes += post.likes || 0
+      })
+    }
+    
+    // 如果用户信息中已有likes字段并且和计算的不一致，更新用户的likes字段
+    if (user.likes !== totalLikes) {
+      await db.collection('users').doc(user._id).update({
+        data: {
+          likes: totalLikes
+        }
+      })
+    }
+
+    return {
+      success: true,
+      count: totalLikes,
+      message: '获取用户获赞数成功'
+    }
+  } catch (error) {
+    console.error('获取用户获赞数失败：', error)
+    return {
+      success: false,
+      message: '获取用户获赞数失败：' + error.message
+    }
+  }
+} 

--- a/cloudfunctions/getUserLikes/package.json
+++ b/cloudfunctions/getUserLikes/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "getUserLikes",
+  "version": "1.0.0",
+  "description": "获取用户获赞数量",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "wx-server-sdk": "latest"
+  }
+} 

--- a/pages/profile/profile.wxml
+++ b/pages/profile/profile.wxml
@@ -42,9 +42,10 @@
         <text class="stat-num">{{userInfo.posts || 0}}</text>
         <text class="stat-label">帖子</text>
       </view>
-      <view class="stat-item">
+      <view class="stat-item" bindtap="onLikesTap">
         <text class="stat-num">{{userInfo.likes || 0}}</text>
         <text class="stat-label">获赞</text>
+        <view class="badge" wx:if="{{newLikes > 0}}">{{newLikes > 99 ? '99+' : newLikes}}</view>
       </view>
       <view class="stat-item">
         <text class="stat-num">{{userInfo.following || 0}}</text>

--- a/pages/profile/profile.wxss
+++ b/pages/profile/profile.wxss
@@ -104,6 +104,7 @@
 
 .stat-item {
   text-align: center;
+  position: relative;
   flex: 1;
 }
 
@@ -111,14 +112,31 @@
   font-size: 32rpx;
   font-weight: 500;
   display: block;
+  margin-bottom: 6rpx;
   color: #333;
 }
 
 .stat-label {
   font-size: 24rpx;
   color: #999;
-  margin-top: 4rpx;
-  display: block;
+}
+
+/* 添加徽章样式 */
+.badge {
+  position: absolute;
+  top: -10rpx;
+  right: -10rpx;
+  min-width: 32rpx;
+  height: 32rpx;
+  padding: 0 6rpx;
+  background-color: #FF4D4F;
+  color: white;
+  border-radius: 16rpx;
+  font-size: 20rpx;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
 }
 
 .function-row {


### PR DESCRIPTION
在用户的"我的"页面添加了获取最新获赞数量的功能
添加了跟踪未读获赞数量的逻辑
在"获赞"项的右上角添加了红色徽章，显示新增的获赞数量
当用户点击"获赞"时，会标记所有获赞为已读，徽章将消失
创建了新的云函数 getUserLikes，用于获取用户发布的所有帖子获得的点赞总数
这些修改共同实现了以下功能：
在"我的"页面中显示了更新后的获赞总数
在"获赞"右上角显示了新增获赞的数量